### PR TITLE
Update base64 encoding in android

### DIFF
--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
@@ -203,7 +203,7 @@ public class VoiceRecorder extends Plugin {
         } catch (IOException exp) {
             return null;
         }
-        return Base64.encodeToString(bArray, Base64.DEFAULT);
+        return Base64.encodeToString(bArray, Base64.NO_WRAP);
     }
 
     private int getMsDurationOfAudioFile(String recordedFilePath) {


### PR DESCRIPTION
- Use `NO_WRAP` for base64 encoding in android